### PR TITLE
use Wallet::network_type not monero.network_type

### DIFF
--- a/qml/pages/MainPage.qml
+++ b/qml/pages/MainPage.qml
@@ -558,6 +558,9 @@ Page {
                 	            } else if(loginError == Enum.LoginError.WalletIsOpenedByAnotherProgram) {
                 	                messageBox.text = qsTr("Wallet is opened by another program")
                 	                messageBox.open()
+                	            } else if(loginError == Enum.LoginError.WalletBadWalletType) {
+                	                messageBox.text = qsTr("Bad wallet type")
+                	                messageBox.open()
                 	            } else if(loginError == Enum.LoginError.DaemonIsNotConnected) {
                 	                messageBox.text = qsTr("Daemon (neromon) is not connected")
                 	                messageBox.open()

--- a/src/console/main.cpp
+++ b/src/console/main.cpp
@@ -48,7 +48,7 @@ int main(int argc, char** argv) {
 
     std::vector<std::string> networks = {"mainnet", "stagenet", "testnet"};
 
-    std::string network_type = Script::get_string(lua_state, "monero.network_type");
+    std::string network_type = Wallet::get_network_type_as_string();
     if (std::find(networks.begin(), networks.end(), network_type) == networks.end()) {
         neroshop::print("\033[1;91mnetwork_type \"" + network_type + "\" is not valid");
         return 1;

--- a/src/core/price/currency_map.hpp
+++ b/src/core/price/currency_map.hpp
@@ -177,7 +177,7 @@ static std::map<std::string, std::tuple<neroshop::Currency, std::string, int, st
     { "BTC", { neroshop::Currency::BTC, "Bitcoin", 8, "₿" } },
     { "ETH", { neroshop::Currency::ETH, "Ether", 18, "" } },    
     { "LTC", { neroshop::Currency::LTC, "Litecoin", 8, "" } },
-    { "WOW", { neroshop::Currency::WOW, "Wownero", 12, "" } },
+    { "WOW", { neroshop::Currency::WOW, "Wownero", 11, "" } },
 };
 
 }

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -21,7 +21,6 @@
 #include <filesystem>
 
 const static std::string lua_string = R"(monero = {
-    network_type = "stagenet", -- TODO: remove this on mainnet release
     nodes = {
         mainnet = {
             "node.community.rino.io:18081",

--- a/src/core/wallet.cpp
+++ b/src/core/wallet.cpp
@@ -169,10 +169,12 @@ int neroshop::Wallet::open(const std::string& path, const std::string& password)
     } catch (const std::exception& e) {
         std::string error_msg = e.what();
         neroshop::print(error_msg, 1);//tools::error::invalid_password
-        if(neroshop::string::contains(error_msg, "wallet cannot be opened")) {
+        if(neroshop::string::contains(error_msg, "wallet cannot be opened as")) {
             return static_cast<int>(WalletError::BadNetworkType);
         } else if(neroshop::string::contains(error_msg, "invalid password")) {
             return static_cast<int>(WalletError::WrongPassword);
+        } else if(neroshop::string::contains(error_msg, "Invalid decimal point specification")) {
+            return static_cast<int>(WalletError::BadWalletType);
         } else {
             return static_cast<int>(WalletError::IsOpenedByAnotherProgram);
         }

--- a/src/core/wallet.hpp
+++ b/src/core/wallet.hpp
@@ -38,6 +38,7 @@ enum class WalletError {
     DoesNotExist,
     BadNetworkType,
     IsNotOpened, // monero_wallet_obj is nullptr
+    BadWalletType,
 };
 
 class Wallet : public monero_wallet_listener {

--- a/src/core/wallet.hpp
+++ b/src/core/wallet.hpp
@@ -4,6 +4,7 @@
 #define WALLET_HPP_NEROSHOP
 
 #define PICONERO 0.000000000001  // the smallest unit of a monero (monero has 12 decimal places) // https://web.getmonero.org/resources/moneropedia/denominations.html
+#define WOWOSHI  0.00000000001   // https://git.wownero.com/wownero/wownero/src/branch/master/src/cryptonote_config.h#L68
 
 #include "wallets/monero.hpp"
 //#include "wallets/wownero.hpp"
@@ -27,6 +28,12 @@ enum class WalletNetworkType : uint8_t { // refer to daemon/monero_daemon_model.
     Mainnet = 0,
     Testnet,
     Stagenet
+};
+
+static std::map<WalletNetworkType, std::vector<std::string>> WalletNetworkPortMap {
+    { WalletNetworkType::Mainnet, { "18081", "18089" } },
+    { WalletNetworkType::Testnet, { "28081", "28089" } },
+    { WalletNetworkType::Stagenet, { "38081", "38089" } },
 };
 
 enum class WalletError {
@@ -103,6 +110,10 @@ public:
     void set_tx_note(const std::string& txid, const std::string& tx_note); // "set_tx_note <txid> [free note text here]" - useful for filling address information
     // getters
     WalletType get_wallet_type() const;
+    WalletNetworkType get_wallet_network_type() const;
+    static WalletNetworkType get_network_type();
+    std::string get_wallet_network_type_as_string() const;
+    static std::string get_network_type_as_string();
     
     double get_sync_percentage() const;
     unsigned long long get_sync_height() const;
@@ -146,8 +157,6 @@ public:
     unsigned int get_daemon_height() const;
     unsigned int get_height() const;
     unsigned int get_height_by_date(int year, int month, int day) const;
-    WalletNetworkType get_network_type() const; // "wallet_info":  Mainnet, Testnet, Stagenet
-    std::string get_network_type_as_string() const; // "wallet_info":  Mainnet, Testnet, Stagenet
     std::string get_status() const; // "status" - Check current status of wallet.
     std::string get_version() const; // "version" - Check software version.
     // get wallet handles (monero, wownero, etc.)

--- a/src/gui/backend.cpp
+++ b/src/gui/backend.cpp
@@ -1600,7 +1600,7 @@ void neroshop::Backend::createOrder(UserController * user_controller, const QStr
 //----------------------------------------------------------------
 QVariantList neroshop::Backend::getNodeListDefault(const QString& coin) const {
     QVariantList node_list;
-    std::string network_type = neroshop::Script::get_string(neroshop::lua_state, "monero.network_type");
+    std::string network_type = Wallet::get_network_type_as_string();
     std::vector<std::string> node_table = neroshop::Script::get_table_string(neroshop::lua_state, coin.toStdString() + ".nodes." + network_type); // Get monero nodes from settings.lua////std::cout << "lua_query: " << coin.toStdString() + ".nodes." + network_type << std::endl;
     for(auto strings : node_table) {
         node_list << QString::fromStdString(strings);
@@ -1608,10 +1608,24 @@ QVariantList neroshop::Backend::getNodeListDefault(const QString& coin) const {
     return node_list;
 }
 //----------------------------------------------------------------
+bool containsSubstring(const std::string& str, const std::vector<std::string>& substrings) {
+    // Iterate over the substrings vector
+    for (const auto& substring : substrings) {
+        // Check if the string contains the current substring
+        if (str.find(substring) != std::string::npos) {
+            return true; // Substring found in the string
+        }
+    }
+    return false; // Substring not found in the string
+}
+//----------------------------------------------------------------
 QVariantList neroshop::Backend::getNodeList(const QString& coin) const {
     const QUrl url(QStringLiteral("https://monero.fail/health.json"));
     QVariantList node_list;
     QString coin_lower = coin.toLower(); // make coin name lowercase
+    
+    WalletNetworkType network_type = Wallet::get_network_type();
+    auto network_ports = WalletNetworkPortMap[network_type];//std::cout << "ports: " << std::get<0>(network_ports) << ", " << std::get<1>(network_ports) << "\n";
     
     QNetworkAccessManager manager;
     QEventLoop loop;
@@ -1623,7 +1637,7 @@ QVariantList neroshop::Backend::getNodeList(const QString& coin) const {
     const auto json_doc = QJsonDocument::fromJson(reply->readAll(), &error);
     // Use fallback monero node list if we fail to get the nodes from the url
     if (error.error != QJsonParseError::NoError) {
-        neroshop::print("Error reading json from " + url.toString().toStdString() + "\nUsing default nodes as fallback", 2);
+        neroshop::print("Error reading json from " + url.toString().toStdString() + "\nUsing default nodes as fallback", 1);
         return getNodeListDefault(coin_lower);
     }
     // Get monero nodes from the JSON
@@ -1634,15 +1648,15 @@ QVariantList neroshop::Backend::getNodeList(const QString& coin) const {
     foreach(const QString& key, clearnet_obj.keys()) {//for (const auto monero_nodes : clearnet_obj) {
         QJsonObject monero_node_obj = clearnet_obj.value(key).toObject();//QJsonObject monero_node_obj = monero_nodes.toObject();
         QVariantMap node_object; // Create an object for each row
-        if(key.contains("38081") || key.contains("38089")) { // Temporarily fetch only stagenet nodes (TODO: change to mainnet port upon release)
-        node_object.insert("address", key);
-        node_object.insert("available", monero_node_obj.value("available").toBool());//std::cout << "available: " << monero_node_obj.value("available").toBool() << "\n";
-        ////node_object.insert("", );//////std::cout << ": " << monero_node_obj.value("checks").toArray() << "\n";
-        node_object.insert("datetime_checked", monero_node_obj.value("datetime_checked").toString());//std::cout << "datetime_checked: " << monero_node_obj.value("datetime_checked").toString().toStdString() << "\n";
-        node_object.insert("datetime_entered", monero_node_obj.value("datetime_entered").toString());//std::cout << "datetime_entered: " << monero_node_obj.value("datetime_entered").toString().toStdString() << "\n";
-        node_object.insert("datetime_failed", monero_node_obj.value("datetime_failed").toString());//std::cout << "datetime_failed: " << monero_node_obj.value("datetime_failed").toString().toStdString() << "\n";
-        node_object.insert("last_height", monero_node_obj.value("last_height").toInt());//std::cout << "last_height: " << monero_node_obj.value("last_height").toInt() << "\n";
-        node_list.append(node_object); // Add node object to the node list
+        if(containsSubstring(key.toStdString(), network_ports)) {
+            node_object.insert("address", key);
+            node_object.insert("available", monero_node_obj.value("available").toBool());//std::cout << "available: " << monero_node_obj.value("available").toBool() << "\n";
+            ////node_object.insert("", );//////std::cout << ": " << monero_node_obj.value("checks").toArray() << "\n";
+            node_object.insert("datetime_checked", monero_node_obj.value("datetime_checked").toString());//std::cout << "datetime_checked: " << monero_node_obj.value("datetime_checked").toString().toStdString() << "\n";
+            node_object.insert("datetime_entered", monero_node_obj.value("datetime_entered").toString());//std::cout << "datetime_entered: " << monero_node_obj.value("datetime_entered").toString().toStdString() << "\n";
+            node_object.insert("datetime_failed", monero_node_obj.value("datetime_failed").toString());//std::cout << "datetime_failed: " << monero_node_obj.value("datetime_failed").toString().toStdString() << "\n";
+            node_object.insert("last_height", monero_node_obj.value("last_height").toInt());//std::cout << "last_height: " << monero_node_obj.value("last_height").toInt() << "\n";
+            node_list.append(node_object); // Add node object to the node list
         }
     }
     return node_list;

--- a/src/gui/backend.cpp
+++ b/src/gui/backend.cpp
@@ -1819,6 +1819,8 @@ int neroshop::Backend::loginWithWalletFile(WalletController* wallet_controller, 
                 return static_cast<int>(EnumWrapper::LoginError::WalletBadNetworkType);
             if(wallet_error == static_cast<int>(WalletError::IsNotOpened))
                 return static_cast<int>(EnumWrapper::LoginError::WalletIsNotOpened);
+            if(wallet_error == static_cast<int>(WalletError::BadWalletType))
+                return static_cast<int>(EnumWrapper::LoginError::WalletBadWalletType);    
         }
         return static_cast<int>(EnumWrapper::LoginError::Ok);
     });

--- a/src/gui/enum_wrapper.hpp
+++ b/src/gui/enum_wrapper.hpp
@@ -21,6 +21,7 @@ public:
         DoesNotExist,
         BadNetworkType,
         IsNotOpened, // monero_wallet_obj is nullptr
+        BadWalletType,
     };    
     Q_ENUM(WalletError)
 
@@ -43,6 +44,7 @@ public:
         WalletDoesNotExist = static_cast<int>(WalletError::DoesNotExist),
         WalletBadNetworkType = static_cast<int>(WalletError::BadNetworkType),
         WalletIsNotOpened = static_cast<int>(WalletError::IsNotOpened),
+        WalletBadWalletType = static_cast<int>(WalletError::BadWalletType),
         
         DaemonIsNotConnected = 10,
         

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -71,14 +71,7 @@ int main(int argc, char *argv[])
     // Configuration file must be loaded right after Qt Application object has been created so that we can get the correct config location
     // open configuration script
     neroshop::load_nodes_from_memory();
-    // Set monero network type
-    std::vector<std::string> networks = { "mainnet", "testnet", "stagenet" };
     
-    std::string network_type = Script::get_string(neroshop::lua_state, "monero.network_type");
-    if (std::find(networks.begin(), networks.end(), network_type) == networks.end()) {
-        neroshop::print("\033[1;91mnetwork_type \"" + network_type + "\" is not valid");
-        return 1;
-    }
     // create "datastore" folder within "~/.config/neroshop/" path
     std::string data_dir = NEROSHOP_DEFAULT_DATABASE_PATH;
     if(!neroshop::filesystem::is_directory(data_dir)) {
@@ -131,7 +124,6 @@ int main(int argc, char *argv[])
     engine.rootContext()->setContextProperty("DaemonManager", &daemonManager);
     // we can also register an instance of a class instead of the class itself
     WalletController *wallet = new WalletController(&engine);
-    wallet->setNetworkTypeByString(QString::fromStdString(network_type));
     engine.rootContext()->setContextProperty("Wallet", wallet);//new WalletController());//qmlRegisterUncreatableType<WalletProxy>("neroshop.Wallet", 1, 0, "Wallet", "Wallet cannot be instantiated directly.");//qmlRegisterType<WalletProxy>("neroshop.Wallet", 1, 0, "Wallet"); // Usage: import neroshop.Wallet  ...  Wallet { id: wallet }
     qRegisterMetaType<WalletController*>(); // Wallet can now be used as an argument in function parameters
     // register script

--- a/src/gui/wallet_controller.cpp
+++ b/src/gui/wallet_controller.cpp
@@ -121,13 +121,13 @@ int neroshop::WalletController::getWalletType() const {
 int neroshop::WalletController::getNetworkType() const {
     if (!_wallet)
         throw std::runtime_error("neroshop::Wallet is not initialized");
-    return static_cast<int>(_wallet->get_network_type());
+    return static_cast<int>(_wallet->get_wallet_network_type());
 }
 
 QString neroshop::WalletController::getNetworkTypeString() const {
     if (!_wallet)
         throw std::runtime_error("neroshop::Wallet is not initialized");
-    return QString::fromStdString(_wallet->get_network_type_as_string());
+    return QString::fromStdString(_wallet->get_wallet_network_type_as_string());
 }
 
 QString neroshop::WalletController::getSeed() const {


### PR DESCRIPTION
* no longer using hard-coded Lua code to set the network type, but `Wallet::network_type` rather
* add `BadWalletType` to `WalletError` enum (checks for incompatible wallet)
* add `WalletNetworkPortMap` std::map to _**wallet.hpp**_
* add `WOWOSHI` macro to _**wallet.hpp**_
* change Wownero decimals from 12 to `11` in _**price/currency_map.hpp**_