### PR TITLE
improve UX a bit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,8 +82,8 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 endif()
 
 ######################################
-set(MONERO_PROJECT "${CMAKE_SOURCE_DIR}/external/monero-cpp/external/monero-project")
-set(MONERO_PROJECT_SRC_DIR "${MONERO_PROJECT}/src")
+set(MONERO_PROJECT_ROOT_DIR "${CMAKE_SOURCE_DIR}/external/monero-cpp/external/monero-project")
+set(MONERO_PROJECT_SRC_DIR "${MONERO_PROJECT_ROOT_DIR}/src")
 
 ####################
 # Extra libraries
@@ -194,7 +194,7 @@ endif()
 
 ######################################
 # Monero
-set(MONERO_PROJECT_BUILD "${MONERO_PROJECT}/build/release" CACHE STRING "Monero project build directory")
+set(MONERO_PROJECT_BUILD "${MONERO_PROJECT_ROOT_DIR}/build/release" CACHE STRING "Monero project build directory")
 message(STATUS "Using monero-project build: " ${MONERO_PROJECT_BUILD})
 
 add_library(wallet STATIC IMPORTED)
@@ -302,10 +302,10 @@ set_target_properties(randomx PROPERTIES IMPORTED_LOCATION
     ${MONERO_PROJECT_BUILD}/external/randomx/librandomx.a)   
     
 ######################################
-set(monero_include_dirs ${MONERO_PROJECT}/contrib/epee/include
-    ${MONERO_PROJECT}/external/
-    ${MONERO_PROJECT}/external/easylogging++
-    ${MONERO_PROJECT}/external/rapidjson/include
+set(monero_include_dirs ${MONERO_PROJECT_ROOT_DIR}/contrib/epee/include
+    ${MONERO_PROJECT_ROOT_DIR}/external/
+    ${MONERO_PROJECT_ROOT_DIR}/external/easylogging++
+    ${MONERO_PROJECT_ROOT_DIR}/external/rapidjson/include
     ${MONERO_PROJECT_SRC_DIR}/
     ${MONERO_PROJECT_SRC_DIR}/wallet
     ${MONERO_PROJECT_SRC_DIR}/wallet/api

--- a/qml/components/NavigationalBar.qml
+++ b/qml/components/NavigationalBar.qml
@@ -31,24 +31,34 @@ RowLayout {
         //checkState: conditionParentBox.checkState
         onClicked: {
             console.log("Selected", button.text, "button")
-            button.checked = true
             if(button.text == walletButton.text) {
+                if(!Wallet.isConnectedToDaemon()) {
+                    button.checked = false
+                    messageBox.text = qsTr("wallet must be connected to a daemon")
+                    messageBox.open()
+                    return
+                }
+                button.checked = true
                 searchBar.children[0].text = ""
                 pageStack.pushPage("qrc:/qml/pages/subpages/WalletPage.qml", StackView.Immediate)//_stackview.currentIndex = 0
             }
             if(button.text == shopButton.text) {
+                button.checked = true
                 searchBar.children[0].text = ""
                 pageStack.pushPage("qrc:/qml/pages/subpages/DashboardPage.qml", StackView.Immediate)
             }
             if(button.text == messagesButton.text) {
+                button.checked = true
                 searchBar.children[0].text = ""
                 pageStack.pushPage("qrc:/qml/pages/subpages/MessagesPage.qml", StackView.Immediate)
             }
             if(button.text == ordersButton.text) {
+                button.checked = true
                 searchBar.children[0].text = ""
                 pageStack.pushPage("qrc:/qml/pages/subpages/OrdersPage.qml", StackView.Immediate)
             }
             if(button.text == accountButton.text) {
+                button.checked = true
                 searchBar.children[0].text = ""
                 pageStack.pushPage("qrc:/qml/pages/subpages/AccountPage.qml", StackView.Immediate)
             }                                                        

--- a/qml/pages/MainPage.qml
+++ b/qml/pages/MainPage.qml
@@ -245,7 +245,11 @@ Page {
                         }
                         if(button.text == restoreFromSeedButton.text) {
                             walletRestoreStack.currentIndex = 1
-                            seedInput.forceActiveFocus()
+                            if(seedInput.text.length > 0) {
+                                walletRestoreHeightField.forceActiveFocus()
+                            } else {
+                                seedInput.forceActiveFocus()
+                            }
                         }
                         if(button.text == restoreFromKeysButton.text) {
                             walletRestoreStack.currentIndex = 2
@@ -486,34 +490,55 @@ Page {
                     background: Rectangle { 
                         color: (NeroshopComponents.Style.darkTheme) ? "#101010" : "#ffffff"
                         border.color: (NeroshopComponents.Style.darkTheme) ? "#a9a9a9" : "#696969"
+                        border.width: walletPasswordRestoreField.activeFocus ? 2 : 1
                         radius: 3
                     }
                     Keys.onEnterPressed: loginButton.activate()
                     Keys.onReturnPressed: loginButton.activate()
                 }                    
                 }
-               Rectangle {//ColumnLayout {
+               Rectangle {
                     id: restoreFromSeed
                     Layout.fillWidth: true
                     Layout.fillHeight: true
-                    border.color: "blue"
-                    
-                    ScrollView {
-                        //Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-                        anchors.fill: parent//width: 500; height: 500
-                        TextArea {
-                            id: seedInput
-                            wrapMode: TextEdit.Wrap
-                            selectByMouse: true      
-                            color: (NeroshopComponents.Style.darkTheme) ? "#ffffff" : "#000000"                  
-                            background: Rectangle {
-                                color: (NeroshopComponents.Style.darkTheme) ? "#101010" : "#f0f0f0"
-                                border.color: (NeroshopComponents.Style.darkTheme) ? "#404040" : "#4d4d4d"
-                                border.width: seedInput.activeFocus ? 2 : 1
-                                //radius: 
+                    color: "transparent"//; border.color: "blue"
+                    ColumnLayout {
+                        anchors.fill: parent
+                        ScrollView {
+                            Layout.fillWidth: true
+                            Layout.fillHeight: true//width: 500; height: 500
+                            TextArea {
+                                id: seedInput
+                                wrapMode: TextEdit.Wrap
+                                selectByMouse: true      
+                                color: (NeroshopComponents.Style.darkTheme) ? "#ffffff" : "#000000"                  
+                                background: Rectangle {
+                                    color: (NeroshopComponents.Style.darkTheme) ? "#101010" : "#f0f0f0"
+                                    border.color: (NeroshopComponents.Style.darkTheme) ? "#404040" : "#4d4d4d"
+                                    border.width: seedInput.activeFocus ? 2 : 1
+                                    radius: 3
+                                }
                             }
                         }
-                    }
+                    
+                        TextField {
+                            id: walletRestoreHeightField
+                            Layout.fillWidth: true
+                            Layout.preferredHeight: 50
+                            placeholderText: qsTr("Restore Height (default: 1570000)"); placeholderTextColor: (NeroshopComponents.Style.darkTheme) ? "#a9a9a9" : "#696969"
+                            color: (NeroshopComponents.Style.darkTheme) ? "#ffffff" : "#000000" // textColor
+                            selectByMouse: true
+                            validator: RegExpValidator{ regExp: /[0-9]*/ }
+                            background: Rectangle { 
+                                color: (NeroshopComponents.Style.darkTheme) ? "#101010" : "#ffffff"
+                                border.color: (NeroshopComponents.Style.darkTheme) ? "#a9a9a9" : "#696969"
+                                border.width: walletRestoreHeightField.activeFocus ? 2 : 1
+                                radius: 3
+                            }
+                            Keys.onEnterPressed: loginButton.activate()
+                            Keys.onReturnPressed: loginButton.activate()
+                        }
+                    } // ColumnLayout
                 }
                 Rectangle {
                     id: restoreFromKeys
@@ -612,7 +637,7 @@ Page {
                 	            return;                	        
                 	        }
                 	        
-                	        let loginError = Backend.loginWithMnemonic(Wallet, seedInput.text, User)
+                	        let loginError = Backend.loginWithMnemonic(Wallet, seedInput.text, Number(walletRestoreHeightField.text), User)
                 	        if(loginError != Enum.LoginError.Ok) {
                 	            console.log("loginError", loginError)
                 	            if(loginError == Enum.LoginError.WalletBadNetworkType) {

--- a/src/core/wallet/monero/monero.cpp
+++ b/src/core/wallet/monero/monero.cpp
@@ -87,14 +87,14 @@ int neroshop::MoneroWallet::create_from_keys(const std::string& primary_address,
 }
 //-------------------------------------------------------
 //-------------------------------------------------------
-int neroshop::MoneroWallet::restore_from_seed(const std::string& seed) 
+int neroshop::MoneroWallet::restore_from_seed(const std::string& seed, uint64_t restore_height) 
 {
     monero::monero_wallet_config wallet_config_obj;
     wallet_config_obj.m_path = ""; // set path to "" for an in-memory wallet
     wallet_config_obj.m_password = "";
     wallet_config_obj.m_network_type = static_cast<monero::monero_network_type>(this->network_type);
     wallet_config_obj.m_seed = seed;
-    wallet_config_obj.m_restore_height = 0;
+    wallet_config_obj.m_restore_height = restore_height;
     
     try {
         monero_wallet_obj = std::unique_ptr<monero_wallet_full>(monero_wallet_full::create_wallet (wallet_config_obj, nullptr));

--- a/src/core/wallet/monero/monero.hpp
+++ b/src/core/wallet/monero/monero.hpp
@@ -16,7 +16,7 @@ public:
     int create_from_seed(const std::string& seed, const std::string& password, const std::string& confirm_pwd, const std::string& path) override;
     int create_from_keys(const std::string& address, const std::string& view_key, const std::string& spend_key, const std::string& password, const std::string &confirm_pwd, const std::string& path) override;
     
-    int restore_from_seed(const std::string& seed) override;
+    int restore_from_seed(const std::string& seed, uint64_t restore_height = 0) override;
     int restore_from_keys(const std::string& primary_address, const std::string& view_key, const std::string& spend_key) override;
     
     int open(const std::string& path, const std::string& password) override;

--- a/src/core/wallet/wallet.cpp
+++ b/src/core/wallet/wallet.cpp
@@ -122,14 +122,14 @@ int neroshop::Wallet::create_from_keys(const std::string& primary_address, const
     return static_cast<int>(WalletError::Ok);
 }
 //-------------------------------------------------------
-int neroshop::Wallet::restore_from_seed(const std::string& seed) 
+int neroshop::Wallet::restore_from_seed(const std::string& seed, uint64_t restore_height) 
 {
     monero::monero_wallet_config wallet_config_obj;
     wallet_config_obj.m_path = ""; // set path to "" for an in-memory wallet
     wallet_config_obj.m_password = "";
     wallet_config_obj.m_network_type = static_cast<monero::monero_network_type>(this->network_type);
     wallet_config_obj.m_seed = seed;
-    wallet_config_obj.m_restore_height = 1570000;//3120000 (mainnet)
+    wallet_config_obj.m_restore_height = (restore_height == 0) ? 1570000 : restore_height;//1570000 (stagenet);3120000 (mainnet)
     
     try {
         monero_wallet_obj = std::unique_ptr<monero_wallet_full>(monero_wallet_full::create_wallet (wallet_config_obj, nullptr));

--- a/src/core/wallet/wallet.hpp
+++ b/src/core/wallet/wallet.hpp
@@ -67,13 +67,13 @@ public:
     virtual int create_from_seed(const std::string& seed, const std::string& password, const std::string& confirm_pwd, const std::string& path);
     virtual int create_from_keys(const std::string& address, const std::string& view_key, const std::string& spend_key, const std::string& password, const std::string &confirm_pwd, const std::string& path);
     
-    virtual int restore_from_seed(const std::string& seed); // In-memory wallet
+    virtual int restore_from_seed(const std::string& seed, uint64_t restore_height = 0); // In-memory wallet
     virtual int restore_from_keys(const std::string& primary_address, const std::string& view_key, const std::string& spend_key); // In-memory wallet
     virtual int open(const std::string& path, const std::string& password); // Password-protected wallet file
     
     virtual void close(bool save = false);
     
-    std::string upload(bool open = true, std::string password = ""); // change to mainnet later    
+    std::string upload(bool open = true, std::string password = "");
     
     bool verify_password(const std::string& password);
     
@@ -105,8 +105,7 @@ public:
     bool daemon_connect_local(const std::string& username = "", const std::string& password = "");
     void daemon_connect_remote(const std::string& ip, const std::string& port, const std::string& username = "", const std::string& password = "", const monero_wallet_listener* listener = nullptr);
     void daemon_close();
-    //void explore_address(const std::string& address); //{Browser::open(this->addr_url + address);}// will detect address before opening explorer
-    //void explore_tx(const std::string& tx_hash);
+    
     void wallet_info();
     
     virtual std::string sign_message(const std::string& message, monero_message_signature_type signature_type) const;

--- a/src/gui/backend.cpp
+++ b/src/gui/backend.cpp
@@ -1897,7 +1897,7 @@ int neroshop::Backend::loginWithWalletFile(WalletController* wallet_controller, 
     return static_cast<int>(EnumWrapper::LoginError::Ok);
 }
 //----------------------------------------------------------------
-int neroshop::Backend::loginWithMnemonic(WalletController* wallet_controller, const QString& mnemonic, UserController * user_controller) {
+int neroshop::Backend::loginWithMnemonic(WalletController* wallet_controller, const QString& mnemonic, unsigned int restore_height, UserController * user_controller) {
     db::Sqlite3 * database = neroshop::get_database();
     if(!database) throw std::runtime_error("database is NULL");
     
@@ -1907,8 +1907,8 @@ int neroshop::Backend::loginWithMnemonic(WalletController* wallet_controller, co
         return static_cast<int>(EnumWrapper::LoginError::DaemonIsNotConnected);
     }
     // Initialize monero wallet with existing wallet mnemonic
-    std::packaged_task<int(void)> restore_wallet_task([wallet_controller, mnemonic]() -> int {
-        int wallet_error = wallet_controller->restoreFromSeed(mnemonic);
+    std::packaged_task<int(void)> restore_wallet_task([wallet_controller, mnemonic, restore_height]() -> int {
+        int wallet_error = wallet_controller->restoreFromSeed(mnemonic, restore_height);
         if(wallet_error != 0) {
             if(wallet_error == static_cast<int>(WalletError::IsOpenedByAnotherProgram))
                 return static_cast<int>(EnumWrapper::LoginError::WalletIsOpenedByAnotherProgram);

--- a/src/gui/backend.hpp
+++ b/src/gui/backend.hpp
@@ -56,7 +56,7 @@ public:
     
     Q_INVOKABLE QVariantList registerUser(WalletController* wallet_controller, const QString& display_name, UserController * user_controller, const QString& avatar);
     Q_INVOKABLE int loginWithWalletFile(WalletController* wallet_controller, const QString& path, const QString& password, UserController * user_controller);
-    Q_INVOKABLE int loginWithMnemonic(WalletController* wallet_controller, const QString& mnemonic, UserController * user_controller);
+    Q_INVOKABLE int loginWithMnemonic(WalletController* wallet_controller, const QString& mnemonic, unsigned int restore_height, UserController * user_controller);
     Q_INVOKABLE int loginWithKeys(WalletController* wallet_controller, UserController * user_controller);
     Q_INVOKABLE int loginWithHW(WalletController* wallet_controller, UserController * user_controller);
     

--- a/src/gui/wallet_controller.cpp
+++ b/src/gui/wallet_controller.cpp
@@ -27,10 +27,10 @@ int neroshop::WalletController::createRandomWallet(const QString& password, cons
     return static_cast<int>(error);
 }
 
-int neroshop::WalletController::restoreFromSeed(const QString& seed) {
+int neroshop::WalletController::restoreFromSeed(const QString& seed, unsigned int restore_height) {
     if (!_wallet)
         throw std::runtime_error("neroshop::Wallet is not initialized");
-    auto error = _wallet->restore_from_seed(seed.toStdString());
+    auto error = _wallet->restore_from_seed(seed.toStdString(), restore_height);
     emit walletChanged();
     if(error == static_cast<int>(WalletError::Ok)) emit isOpenedChanged();
     return static_cast<int>(error);

--- a/src/gui/wallet_controller.hpp
+++ b/src/gui/wallet_controller.hpp
@@ -28,7 +28,7 @@ class WalletController : public QObject, public monero_wallet_listener
 public:
     // functions (for use in QML)
     Q_INVOKABLE int createRandomWallet(const QString& password, const QString& confirm_pwd, const QString& path);
-    Q_INVOKABLE int restoreFromSeed(const QString& seed);
+    Q_INVOKABLE int restoreFromSeed(const QString& seed, unsigned int restore_height);
     Q_INVOKABLE int restoreFromKeys(const QString& primary_address, const QString& private_view_key, const QString& private_spend_key);
     Q_INVOKABLE int open(const QString& path, const QString& password);
     Q_INVOKABLE void close(bool save = false);


### PR DESCRIPTION
- **WalletPage.qml** cannot be open while wallet is not connected to daemon
- `walletRestoreHeightField` only accepts integer number inputs
- restore height can now be set when restoring a wallet from mnemonic (seed phrase)
- default restore height set to `1570000` to increase sync speed
- remove some unnecessary comments