### PR TITLE
backup

### DIFF
--- a/qml/pages/subpages/WalletPage.qml
+++ b/qml/pages/subpages/WalletPage.qml
@@ -169,13 +169,12 @@ Page {
                                     radius: 5
                                     Rectangle {
                                         anchors.verticalCenter: parent.verticalCenter
-                                        anchors.left: parent.left; anchors.leftMargin: 5
-                                        width: parent.height - 10; height: width
+                                        anchors.left: parent.left; anchors.leftMargin: 20
+                                        width: childrenRect.width; height: childrenRect.height
                                         color: "transparent"
-                                        border.color: balanceTxColumn.borderColor
+                                        //border.color: balanceTxColumn.borderColor
                                     
                                         Text {
-                                            anchors.centerIn: parent
                                             text: modelData.is_incoming ? "\uf063" : "\uf062"
                                             color: (!Wallet.opened) ? "#ffffff" : (modelData.is_incoming ? "#2cba78" : "#c32235")
                                             font.bold: true; font.family: FontAwesome.fontFamily
@@ -283,13 +282,38 @@ Page {
                                     id: txDetailsRect
                                     anchors.horizontalCenter: parent.horizontalCenter
                                     width: parent.width - 10
-                                    height: 25
+                                    height: 225
                                     color: balanceTxColumn.baseColor
                                     visible: false
-                                    Text {
-                                        anchors.centerIn: parent
-                                        text: "Additional Transaction Details"
-                                        color: balanceTxColumn.textColor
+                                    Column {
+                                        anchors.fill: parent
+                                        anchors.margins: 20
+                                        spacing: 15
+                                        Text {
+                                            text: qsTr("Fee: %1").arg("")
+                                            color: balanceTxColumn.textColor
+                                        }
+                                        Text {
+                                            text: qsTr("Transaction ID: %1").arg("")
+                                            color: balanceTxColumn.textColor
+                                        }
+                                        Text {
+                                            text: qsTr("Destination address: %1").arg("")
+                                            color: balanceTxColumn.textColor
+                                            visible: !modelData.is_incoming
+                                        }
+                                        Text {
+                                            text: qsTr("Block height: %1").arg("")
+                                            color: balanceTxColumn.textColor
+                                        }
+                                        Text {
+                                            text: qsTr("Notes: %1").arg("")
+                                            color: balanceTxColumn.textColor
+                                        }
+                                        Text {
+                                            text: qsTr("Timestamp: %1").arg("")
+                                            color: balanceTxColumn.textColor
+                                        }
                                     }
                                 }
                             } // Column

--- a/src/core/protocol/messages/msgpack.cpp
+++ b/src/core/protocol/messages/msgpack.cpp
@@ -246,13 +246,10 @@ std::vector<uint8_t> process(const std::vector<uint8_t>& request, Node& node, bo
         }
                    
         // Store the key-value pair in your own node as well
-        if(node.store(key, value)) {
+        if(node.cache(key, value)) {
             if(put_messages_sent == 0) { 
                 code = static_cast<int>(DhtResultCode::StoreToSelf);
             }
-            
-            // Store your local client's own data on-disk (in case of outage)
-            node.cache(key, value);
             
             // Map keys to search terms for efficient search operations
             node.map(key, value);

--- a/src/core/protocol/messages/msgpack.cpp
+++ b/src/core/protocol/messages/msgpack.cpp
@@ -187,10 +187,6 @@ std::vector<uint8_t> process(const std::vector<uint8_t>& request, Node& node, bo
                ? static_cast<int>(DhtResultCode::StoreFailed) 
                : static_cast<int>(DhtResultCode::Success);
             
-        if(code == static_cast<int>(DhtResultCode::Success)) {
-            node.map(key, value);
-        }
-        
         if(code != static_cast<int>(DhtResultCode::Success)) {
             response_object["version"] = std::string(NEROSHOP_DHT_VERSION);
             response_object["error"]["id"] = node.get_id();
@@ -237,10 +233,6 @@ std::vector<uint8_t> process(const std::vector<uint8_t>& request, Node& node, bo
             code = static_cast<int>(DhtResultCode::StorePartial);
         }
         
-        if((!Node::is_value_republishable(value)) && (put_messages_sent == 0)) {
-            code = static_cast<int>(DhtResultCode::DataRejected);
-        }
-                   
         // Store the key-value pair in your own node as well
         if(node.store(key, value)) {
             if(put_messages_sent == 0) { 
@@ -296,7 +288,7 @@ std::vector<uint8_t> process(const std::vector<uint8_t>& request, Node& node, bo
         }
     }    
     //-----------------------------------------------------
-    response_object["tid"] = tid; // transaction id - MUST be the same as the request object's tid
+    response_object["tid"] = tid;
     response = nlohmann::json::to_msgpack(response_object);
     return response;
 }

--- a/src/core/protocol/messages/msgpack.cpp
+++ b/src/core/protocol/messages/msgpack.cpp
@@ -237,6 +237,10 @@ std::vector<uint8_t> process(const std::vector<uint8_t>& request, Node& node, bo
         if((put_messages_sent < NEROSHOP_DHT_REPLICATION_FACTOR) && (put_messages_sent > 0)) {
             code = static_cast<int>(DhtResultCode::StorePartial);
         }
+        
+        if((!Node::is_value_republishable(value)) && (put_messages_sent == 0)) {
+            code = static_cast<int>(DhtResultCode::DataRejected);
+        }
                    
         // Store the key-value pair in your own node as well
         if(node.store(key, value)) {

--- a/src/core/protocol/messages/msgpack.cpp
+++ b/src/core/protocol/messages/msgpack.cpp
@@ -99,19 +99,7 @@ std::vector<uint8_t> process(const std::vector<uint8_t>& request, Node& node, bo
         // Check if the queried node has peers for the requested key
         std::vector<Peer> peers = node.get_providers(key);
         if(peers.empty()) {
-            // WARNING!!! THIS CODE MAY BLOCK THE GUI.
-            std::vector<Node*> closest_nodes = node.find_node(key, NEROSHOP_DHT_MAX_CLOSEST_NODES);
-            std::vector<nlohmann::json> nodes_array;
-            for (const auto& n : closest_nodes) {
-                nlohmann::json node_object = {
-                    {"id", n->get_id()},
-                    {"ip_address", n->get_ip_address()},
-                    {"port", n->get_port()}
-                };
-                nodes_array.push_back(node_object);
-                //std::cout << "Node ID: " << n->get_id() << ", Node IP address: " << n->get_ip_address() << ", Node port: " << n->get_port() << std::endl;
-            }
-            response_object["response"]["nodes"] = nodes_array; // If the queried node has no peers for the infohash, a key "nodes" is returned containing the K nodes in the queried nodes routing table closest to the infohash supplied in the query
+            response_object["response"]["values"] = nlohmann::json::array();
         } else {
             std::vector<nlohmann::json> peers_array;
             for (const auto& p : peers) {

--- a/src/core/protocol/p2p/dht_rescode.hpp
+++ b/src/core/protocol/p2p/dht_rescode.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <iostream>
+#include <string>
+
 namespace neroshop {
 
 enum class DhtResultCode {
@@ -22,6 +25,7 @@ enum class DhtResultCode {
     InvalidRequest,
     ParseError,
     DataVerificationFailed,
+    DataRejected,
     RemoveFailed,
 };
 
@@ -63,6 +67,10 @@ static std::string get_dht_result_code_as_string(DhtResultCode result_code) {
             return "Invalid request";
         case DhtResultCode::ParseError:
             return "Parse error";
+        case DhtResultCode::DataVerificationFailed:
+            return "Data verification failed";
+        case DhtResultCode::DataRejected:
+            return "Data rejected";
         case DhtResultCode::RemoveFailed:
             return "Remove failed";
         default:

--- a/src/core/protocol/p2p/dht_rescode.hpp
+++ b/src/core/protocol/p2p/dht_rescode.hpp
@@ -22,6 +22,7 @@ enum class DhtResultCode {
     InvalidRequest,
     ParseError,
     DataVerificationFailed,
+    RemoveFailed,
 };
 
 static std::string get_dht_result_code_as_string(DhtResultCode result_code) {
@@ -62,6 +63,8 @@ static std::string get_dht_result_code_as_string(DhtResultCode result_code) {
             return "Invalid request";
         case DhtResultCode::ParseError:
             return "Parse error";
+        case DhtResultCode::RemoveFailed:
+            return "Remove failed";
         default:
             return "Unknown result code";
     }

--- a/src/core/protocol/p2p/dht_rescode.hpp
+++ b/src/core/protocol/p2p/dht_rescode.hpp
@@ -25,7 +25,6 @@ enum class DhtResultCode {
     InvalidRequest,
     ParseError,
     DataVerificationFailed,
-    DataRejected,
     RemoveFailed,
 };
 
@@ -69,8 +68,6 @@ static std::string get_dht_result_code_as_string(DhtResultCode result_code) {
             return "Parse error";
         case DhtResultCode::DataVerificationFailed:
             return "Data verification failed";
-        case DhtResultCode::DataRejected:
-            return "Data rejected";
         case DhtResultCode::RemoveFailed:
             return "Remove failed";
         default:

--- a/src/core/protocol/p2p/node.cpp
+++ b/src/core/protocol/p2p/node.cpp
@@ -600,7 +600,7 @@ bool Node::send_ping(const std::string& address, int port) {
     try {
         pong_message = nlohmann::json::from_msgpack(receive_buffer);
     } catch (const std::exception& e) {
-        std::cerr << "Node \033[91m" << address << ":" << port << "\033[0m did not respond" << std::endl;
+        std::cerr << "\033[91mNode " << address << ":" << port << " did not respond\033[0m" << std::endl;
         return false;
     }
     if (!pong_message.contains("response") || pong_message.contains("error")) {
@@ -1855,11 +1855,13 @@ bool Node::is_value_republishable(const std::string& value) {
         return false; // Invalid value, return false
     }
 
+    if(!json.is_object()) { return false; }
     if(!json.contains("metadata")) { return false; }
     if(!json["metadata"].is_string()) { return false; }
     std::string metadata = json["metadata"].get<std::string>();
     
-    return (metadata != "listing");
+    std::vector<std::string> non_publishable_metadatas = { "listing" };
+    return (std::find(non_publishable_metadatas.begin(), non_publishable_metadatas.end(), metadata) == non_publishable_metadatas.end());
 }
 
 //-----------------------------------------------------------------------------

--- a/src/core/protocol/p2p/node.hpp
+++ b/src/core/protocol/p2p/node.hpp
@@ -78,6 +78,7 @@ public:
     std::string send_find_value(const std::string& key);
     void send_remove(const std::string& key);
     void send_map(const std::string& address, int port); // Distributes indexing data to a single node
+    void send_map_v2(const std::string& address, int port);
     std::vector<Peer> send_get_providers(const std::string& data_hash);
     //---------------------------------------------------
     ////std::vector<Node*> lookup(const std::string& key); // In Kademlia, the primary purpose of the lookup function is to find the nodes responsible for storing a particular key in the DHT, rather than retrieving the actual value of the key. The lookup function helps in locating the nodes that are likely to have the key or be able to provide information about it.
@@ -92,7 +93,7 @@ public:
     void refresh();
     void republish();
     bool validate(const std::string& key, const std::string& value); // Validates data before storing it
-    void cache(const std::string& key, const std::string& value); // Cache data created by local client
+    int cache(const std::string& key, const std::string& value); // Cache data created by local client
     //---------------------------------------------------
     void persist_routing_table(const std::string& address, int port); // JIC bootstrap node faces outage and needs to recover
     void rebuild_routing_table(); // Re-builds routing table from data stored on disk
@@ -141,6 +142,7 @@ public:
     bool is_hardcoded() const;
     static bool is_hardcoded(const std::string& address, uint16_t port);
     bool has_key(const std::string& key) const;
+    bool has_key_cached(const std::string& key) const;
     bool has_value(const std::string& value) const;
     bool is_dead() const;
 };

--- a/src/core/protocol/p2p/node.hpp
+++ b/src/core/protocol/p2p/node.hpp
@@ -14,7 +14,7 @@ const int NUM_BITS = 256;
 
 namespace neroshop {
 
-class RoutingTable; // forward declaration
+class RoutingTable;
 class KeyMapper;
 
 struct Peer {
@@ -38,7 +38,9 @@ private:
     std::unique_ptr<RoutingTable> routing_table; // Pointer to the node's routing table
     friend class RoutingTable;
     friend class Server;
+public:
     std::string public_ip_address;
+private:
     bool bootstrap;
     int check_counter; // Counter to track the number of consecutive failed checks
     mutable std::shared_mutex data_mutex;

--- a/src/core/protocol/p2p/node.hpp
+++ b/src/core/protocol/p2p/node.hpp
@@ -145,6 +145,7 @@ public:
     bool has_key_cached(const std::string& key) const;
     bool has_value(const std::string& value) const;
     bool is_dead() const;
+    static bool is_value_republishable(const std::string& value);
 };
 
 }

--- a/src/core/protocol/transport/client.cpp
+++ b/src/core/protocol/transport/client.cpp
@@ -261,6 +261,27 @@ void Client::set(const std::string& key, const std::string& value, std::string& 
         std::cerr << "An error occurred: " << "Node was disconnected" << std::endl;
     }
 }
+
+void Client::remove(const std::string& key, std::string& reply) {
+    // Send remove - no id or tid required for IPC client requests. The DHT server will deal with that
+    nlohmann::json args_obj = { {"key", key} };
+    nlohmann::json query_object = { {"version", std::string(NEROSHOP_DHT_VERSION)}, {"query", "remove"}, {"args", args_obj}, {"tid", nullptr} };
+    std::vector<uint8_t> packed_data = nlohmann::json::to_msgpack(query_object);
+    send(packed_data);
+    // Receive response
+    try {
+        std::vector<uint8_t> response;
+        receive(response);
+        try {
+            nlohmann::json response_object = nlohmann::json::from_msgpack(response);
+            reply = response_object.dump();//return response_object.dump();
+        } catch (const nlohmann::detail::parse_error& e) {
+            std::cerr << "Failed to parse server response: " << e.what() << std::endl;
+        }
+    } catch (const nlohmann::detail::parse_error& e) {
+        std::cerr << "An error occurred: " << "Node was disconnected" << std::endl;
+    }
+}
 ////////////////////	
 void Client::close() {
 	::close(sockfd);

--- a/src/core/protocol/transport/client.hpp
+++ b/src/core/protocol/transport/client.hpp
@@ -57,6 +57,7 @@ public:
 	void put(const std::string& key, const std::string& value, std::string& response);
 	void get(const std::string& key, std::string& response);
 	void set(const std::string& key, const std::string& value, std::string& response);
+	void remove(const std::string& key, std::string& response);
 	void close(); // kills socket
 	void shutdown(); // shuts down connection (disconnects from server)
     void disconnect(); // breaks connection to server then closes the client socket // combination of shutdown() and close()

--- a/src/gui/backend.cpp
+++ b/src/gui/backend.cpp
@@ -583,8 +583,9 @@ QVariantList neroshop::Backend::getProductRatings(const QString& product_id) {
             // Parse the response
             nlohmann::json json = nlohmann::json::parse(response);
             if(json.contains("error")) {
-                int rescode = database->execute_params("DELETE FROM mappings WHERE key = ?1", { key.toStdString() });
-                if(rescode != SQLITE_OK) neroshop::print("sqlite error: DELETE failed", 1);
+                std::string response2;
+                client->remove(key.toStdString(), response2);
+                std::cout << "Received response (remove): " << response2 << "\n";
                 //emit productRatingsChanged();
                 continue; // Key is lost or missing from DHT, skip to next iteration
             }
@@ -721,8 +722,9 @@ QVariantList neroshop::Backend::getSellerRatings(const QString& user_id) {
             // Parse the response
             nlohmann::json json = nlohmann::json::parse(response);
             if(json.contains("error")) {
-                int rescode = database->execute_params("DELETE FROM mappings WHERE key = ?1", { key.toStdString() });
-                if(rescode != SQLITE_OK) neroshop::print("sqlite error: DELETE failed", 1);
+                std::string response2;
+                client->remove(key.toStdString(), response2);
+                std::cout << "Received response (remove): " << response2 << "\n";
                 //emit sellerRatingsChanged();
                 continue; // Key is lost or missing from DHT, skip to next iteration
             }
@@ -792,8 +794,9 @@ QVariantMap neroshop::Backend::getUser(const QString& user_id) {
     // Parse the response
     nlohmann::json json = nlohmann::json::parse(response);
     if(json.contains("error")) {
-        int rescode = database->execute_params("DELETE FROM mappings WHERE key = ?1", { key });
-        if(rescode != SQLITE_OK) neroshop::print("sqlite error: DELETE failed", 1);
+        std::string response2;
+        client->remove(key, response2);
+        std::cout << "Received response (remove): " << response2 << "\n";
         return {}; // Key is lost or missing from DHT, skip to next iteration
     }
     
@@ -851,8 +854,9 @@ int neroshop::Backend::getStockAvailable(const QString& product_id) {
     // Parse the response
     nlohmann::json json = nlohmann::json::parse(response);
     if(json.contains("error")) {
-        int rescode = database->execute_params("DELETE FROM mappings WHERE key = ?1", { key });
-        if(rescode != SQLITE_OK) neroshop::print("sqlite error: DELETE failed", 1);
+        std::string response2;
+        client->remove(key, response2);
+        std::cout << "Received response (remove): " << response2 << "\n";
         return 0; // Key is lost or missing from DHT, return 
     }    
     
@@ -915,8 +919,9 @@ QVariantList neroshop::Backend::getInventory(const QString& user_id, bool hide_i
             // Parse the response
             nlohmann::json json = nlohmann::json::parse(response);
             if(json.contains("error")) {
-                int rescode = database->execute_params("DELETE FROM mappings WHERE key = ?1", { key.toStdString() });
-                if(rescode != SQLITE_OK) neroshop::print("sqlite error: DELETE failed", 1);
+                std::string response2;
+                client->remove(key.toStdString(), response2);
+                std::cout << "Received response (remove): " << response2 << "\n";
                 continue; // Key is lost or missing from DHT, skip to next iteration
             }
             
@@ -1061,8 +1066,9 @@ QVariantList neroshop::Backend::getListingsBySearchTerm(const QString& searchTer
             // Parse the response
             nlohmann::json json = nlohmann::json::parse(response);
             if(json.contains("error")) { 
-                int rescode = database->execute_params("DELETE FROM mappings WHERE key = ?1", { key.toStdString() });
-                if(rescode != SQLITE_OK) neroshop::print("sqlite error: DELETE failed", 1);
+                std::string response2;
+                client->remove(key.toStdString(), response2);
+                std::cout << "Received response (remove): " << response2 << "\n";
                 //emit categoryProductCountChanged();//(category_id);
                 //emit searchResultsChanged();
                 continue; // Key is lost or missing from DHT, skip to next iteration
@@ -1190,8 +1196,9 @@ QVariantList neroshop::Backend::getListings(int sorting, bool hide_illicit_items
             // Parse the response
             nlohmann::json json = nlohmann::json::parse(response);
             if(json.contains("error")) {
-                int rescode = database->execute_params("DELETE FROM mappings WHERE key = ?1", { key.toStdString() });
-                if(rescode != SQLITE_OK) neroshop::print("sqlite error: DELETE failed", 1);
+                std::string response2;
+                client->remove(key.toStdString(), response2);
+                std::cout << "Received response (remove): " << response2 << "\n";
                 //emit categoryProductCountChanged();//(category_id);
                 //emit searchResultsChanged();
                 continue; // Key is lost or missing from DHT, skip to next iteration
@@ -1416,8 +1423,9 @@ QVariantList neroshop::Backend::getListingsByCategory(int category_id, bool hide
             // Parse the response
             nlohmann::json json = nlohmann::json::parse(response);
             if(json.contains("error")) {
-                int rescode = database->execute_params("DELETE FROM mappings WHERE key = ?1", { key.toStdString() });
-                if(rescode != SQLITE_OK) neroshop::print("sqlite error: DELETE failed", 1);
+                std::string response2;
+                client->remove(key.toStdString(), response2);
+                std::cout << "Received response (remove): " << response2 << "\n";
                 //emit categoryProductCountChanged();//(category_id);
                 //emit searchResultsChanged();
                 continue; // Key is lost or missing from DHT, skip to next iteration

--- a/src/gui/user_controller.cpp
+++ b/src/gui/user_controller.cpp
@@ -317,8 +317,9 @@ QVariantList neroshop::UserController::getInventory(int sorting) const {
             // Parse the response
             nlohmann::json json = nlohmann::json::parse(response);
             if(json.contains("error")) {
-                int rescode = database->execute_params("DELETE FROM mappings WHERE key = ?1", { key.toStdString() });
-                if(rescode != SQLITE_OK) neroshop::print("sqlite error: DELETE failed", 1);
+                std::string response2;
+                client->remove(key.toStdString(), response2);
+                std::cout << "Received response (remove): " << response2 << "\n";
                 //emit productsCountChanged();
                 //emit inventoryChanged();
                 continue; // Key is lost or missing from DHT, skip to next iteration
@@ -536,8 +537,9 @@ QVariantList neroshop::UserController::getMessages() const {
             // Parse the response
             nlohmann::json json = nlohmann::json::parse(response);
             if(json.contains("error")) {
-                int rescode = database->execute_params("DELETE FROM mappings WHERE key = ?1", { key.toStdString() });
-                if(rescode != SQLITE_OK) neroshop::print("sqlite error: DELETE failed", 1);
+                std::string response2;
+                client->remove(key.toStdString(), response2);
+                std::cout << "Received response (remove): " << response2 << "\n";
                 continue; // Key is lost or missing from DHT, skip to next iteration
             }
             

--- a/src/gui/wallet_controller.cpp
+++ b/src/gui/wallet_controller.cpp
@@ -282,6 +282,7 @@ QVariantList neroshop::WalletController::getTransfers() const {
     std::packaged_task<QVariantList(void)> get_transfers_task([this]() -> QVariantList {
         monero_transfer_query transfer_query; // optional
         auto transfers = _wallet->get_monero_wallet()->get_transfers(transfer_query);
+        //auto txs = _wallet->get_monero_wallet()->get_txs();//(transfer_query);
 
         QVariantList transfers_list;
 
@@ -296,6 +297,8 @@ QVariantList neroshop::WalletController::getTransfers() const {
             monero_tx_wallet * tx_wallet = transfer->m_tx.get(); // refer to: https://woodser.github.io/monero-cpp/doxygen/structmonero_1_1monero__tx__wallet.html
             ////transfer_object.insert("", tx_wallet->);
             //std::cout << ": " << tx_wallet-> << "\n";
+            
+            // TODO: get fees, tx id, block height, note, and timestamp
         
             transfers_list.append(transfer_object);
         }

--- a/src/neroshop_config.hpp
+++ b/src/neroshop_config.hpp
@@ -117,7 +117,7 @@ namespace neroshop {
 
 const std::initializer_list<std::pair<std::string, uint16_t>> BOOTSTRAP_NODES = {
     {"node.neroshop.org", NEROSHOP_P2P_DEFAULT_PORT},
-    //{"127.0.0.1", NEROSHOP_P2P_DEFAULT_PORT}
+    {"127.0.0.1", NEROSHOP_P2P_DEFAULT_PORT}
 };
 
 }


### PR DESCRIPTION
* added "remove" query type  which can only be used in local IPC mode.
* listings are no longer published to the network but instead stored locally in the database file rather than in the in-memory hash table. This means that listings are now 100% self-hosted and once a node goes offline, its listings will not be visible to the network. The PROs about this is that listings can now be modified and can actually be deleted.
* listings can be discovered through `map` requests, which now uses the node's own hash table (data) taken directly from the local database file. Peers (nodes) can only send map requests containing data created locally by the client.