### PR TITLE
backup

### DIFF
--- a/qml/components/PeerList.qml
+++ b/qml/components/PeerList.qml
@@ -125,7 +125,7 @@ Item {
                     Label {
                         id: peerAddressLabel
                         Layout.fillWidth: true
-                        text: (typeof modelData !== "object") ? "" : (modelData.address + ":" + modelData.port.toString())
+                        text: (typeof modelData !== "object") ? "" : modelData.address//(modelData.address + ":" + modelData.port.toString())
                         color: delegateRow.parent.ListView.isCurrentItem ? "#471d00" : ((NeroshopComponents.Style.darkTheme) ? "#ffffff" : "#000000")
                         font.bold: delegateRow.parent.ListView.isCurrentItem ? true : false
                         elide: Label.ElideRight
@@ -145,7 +145,7 @@ Item {
                         id: peerDistanceLabel
                         Layout.minimumWidth: distanceTitle.width
                         Layout.maximumWidth: distanceTitle.width
-                        text: (typeof modelData !== "object") ? "- -" : "???"//modelData.distance
+                        text: (typeof modelData !== "object") ? "- -" : modelData.distance
                         color: peerAddressLabel.color
                         font.bold: peerAddressLabel.font.bold
                         elide: Label.ElideRight

--- a/src/core/protocol/p2p/key_mapper.hpp
+++ b/src/core/protocol/p2p/key_mapper.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <utility> // std::pair
 #include <shared_mutex>
 
 namespace neroshop {

--- a/src/core/protocol/p2p/node.hpp
+++ b/src/core/protocol/p2p/node.hpp
@@ -82,18 +82,6 @@ public:
     void remove_provider(const std::string& data_hash, const std::string& i2p_address);
     std::deque<Peer> get_providers(const std::string& data_hash) const; // A query to get a list of peers for a specific torrent or infohash.
     
-    // Callbacks
-    void on_ping(const std::vector<uint8_t>& buffer, const std::string& destination);
-    void on_map(const std::vector<uint8_t>& buffer, const std::string& destination);
-    ////void on_dead_node(const std::vector<std::string>& node_ids);
-    ////bool on_keyword_blocked(const std::string& keyword);
-    ////bool on_node_blacklisted(const std::string& address);
-    ////bool on_data_expired();
-    void periodic_check();
-    void periodic_refresh(); // Periodically sends find_node queries
-    void periodic_republish(); // Periodically republishes in-memory hash table data
-    void periodic_purge(); // Periodically removes expired in-memory hash table data
-    
     // Getters
     std::string get_id() const; // get ID of this node
     SamClient * get_sam_client() const;
@@ -132,6 +120,18 @@ public:
     // Friends
     friend class RoutingTable;
 private:
+    // Callbacks
+    void on_ping(const std::vector<uint8_t>& buffer, const std::string& destination);
+    void on_map(const std::vector<uint8_t>& buffer, const std::string& destination);
+    ////void on_dead_node(const std::vector<std::string>& node_ids);
+    ////bool on_keyword_blocked(const std::string& keyword);
+    ////bool on_node_blacklisted(const std::string& address);
+    ////bool on_data_expired();
+    void heartbeat();
+    void periodic_refresh(); // Periodically sends find_node queries
+    void periodic_republish(); // Periodically republishes in-memory hash table data
+    void periodic_purge(); // Periodically removes expired in-memory hash table data
+    
     std::string generate_node_id(const std::string& i2p_address);
     // Determines if node1 is closer to the target_id than node2
     bool is_closer(const std::string& target_id, const std::string& node1_id, const std::string& node2_id);
@@ -155,7 +155,7 @@ private:
     std::atomic<int> check_counter; // Counter to track the number of consecutive failed checks
     std::unordered_map<std::string, std::promise<nlohmann::json>> pending_requests; // Shared between sender and listener
     std::mutex pending_mutex;
-    // For periodic_check() thread
+    // For heartbeat() thread
     void stop_periodic_check();
     bool stop_period_chk_flag;
     std::condition_variable cv;

--- a/src/core/protocol/p2p/routing_table.hpp
+++ b/src/core/protocol/p2p/routing_table.hpp
@@ -4,7 +4,7 @@
 #include <string>
 #include <array>          // for std::array
 #include <vector>         // for std::vector
-#include <memory>         // for std::shared_ptr
+#include <memory>         // for std::shared_ptr, std::unique_ptr
 #include <shared_mutex>   // for std::shared_mutex
 
 #include "../../../neroshop_config.hpp"
@@ -13,7 +13,7 @@ namespace neroshop {
 
 class Node; // forward declaration
 
-constexpr int BUCKET_COUNT = NEROSHOP_DHT_ROUTING_TABLE_BUCKETS;
+constexpr int BUCKET_COUNT = NEROSHOP_DHT_ROUTING_TABLE_BUCKETS; // should be 256
 using xor_id = std::array<uint8_t, BUCKET_COUNT / 8>; // should be equivalent to: std::array<uint8_t, 32>
 
 using Bucket = std::vector<std::shared_ptr<Node>>;
@@ -25,7 +25,7 @@ public:
     RoutingTable(const xor_id&      node_id); // XOR ID
 
     // Add a new node to the routing table
-    bool add_node(std::shared_ptr<Node> node);
+    bool add_node(std::unique_ptr<Node> node);
     
     bool remove_node(const std::string& address, uint16_t port);
     bool remove_node(const std::string& node_id);
@@ -35,11 +35,12 @@ public:
     // Print the contents of the routing table
     void print_table() const;    
     
-    std::vector<Node*> find_closest_nodes(const std::string& key, int count = NEROSHOP_DHT_MAX_CLOSEST_NODES);// const;// K or count is the maximum number of closest nodes to return
-    Node* get_node_by_id(const std::string& node_id) const;
+    std::vector<std::weak_ptr<Node>> find_closest_nodes(const std::string& key, int count = NEROSHOP_DHT_MAX_CLOSEST_NODES);// const;// K or count is the maximum number of closest nodes to return
+    std::weak_ptr<Node> get_node_by_id(const std::string& node_id) const;
 
     // Find the bucket index that a given node belongs in
     int get_bucket_index(const std::string& node_id) const;
+    static int get_bucket_index(const std::string& lhs, const std::string& rhs);
     
     int get_bucket_count() const;
     int get_node_count() const;

--- a/src/core/protocol/rpc/msgpack.cpp
+++ b/src/core/protocol/rpc/msgpack.cpp
@@ -35,7 +35,7 @@ std::vector<uint8_t> process(const std::vector<uint8_t>& request, Node& node, bo
     // Process (parse) the request
     try {
         request_object = nlohmann::json::from_msgpack(request);
-        std::cout << "\033[33m" << request_object.dump() << "\033[0m" << std::endl;
+        //std::cout << "\033[33m" << request_object.dump() << "\033[0m" << std::endl;
     }
     catch(nlohmann::json::parse_error& exception) {
         neroshop::log_error("Error parsing client request");

--- a/src/core/protocol/transport/sam_client.hpp
+++ b/src/core/protocol/transport/sam_client.hpp
@@ -89,7 +89,7 @@ struct SamDatagram {
     std::vector<uint8_t> payload; // raw msgpack payload
     std::string destination; // base64 public destination key
     std::string header;  // full SAM header line
-    // TODO: FROM_PORT=, TO_PORT=, and size
+    // TODO: FROM_PORT=, TO_PORT=, and SIZE
 };
 
 class SamClient {
@@ -155,7 +155,7 @@ private:
     std::string public_key; // base64 public destination key
     std::string i2p_address;
     int session_socket; // for SAM commands like SESSION CREATE (control socket)
-    int client_socket; // for data transmission
+    int client_socket; // for data transmission // TODO: split client_socket into two separate sockets for TCP and UDP
     uint16_t client_port; // both client TCP and UDP sockets are able to share the same port without conflict
 };
 

--- a/src/core/tools/device.hpp
+++ b/src/core/tools/device.hpp
@@ -27,9 +27,13 @@ namespace device {
 	    #endif    
 	    #ifdef __gnu_linux__ // works!
 	    uid_t uid = geteuid();
-		struct passwd * pw = getpwuid(uid);
-        if(!pw) return "";
-        return std::string(pw->pw_name);
+		struct passwd pwd;
+        struct passwd* result = nullptr;
+        std::vector<char> buffer(16384); // 16 KB
+        
+        int ret = getpwuid_r(uid, &pwd, buffer.data(), buffer.size(), &result);
+        if(ret != 0 || result == nullptr) return "";
+        return std::string(pwd.pw_name);
 	    #endif    
 	    return "";
 	}

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -259,7 +259,7 @@ int main(int argc, char** argv)
     std::thread rpc_thread;  // Declare the thread object // RPC communication for processing requests from outside clients (disabled by default)
     
     if(result.count("rpc")) {
-        std::cout << "RPC enabled\n";
+        log_info("RPC enabled, listening on port {} using JSON-RPC 2.0", NEROSHOP_RPC_DEFAULT_PORT);
         rpc_thread = std::thread(rpc_server, std::cref(ip_address));  // Initialize the thread object 
     }
     

--- a/src/gui/backend.cpp
+++ b/src/gui/backend.cpp
@@ -2434,7 +2434,9 @@ QVariantMap neroshop::Backend::getNetworkStatus() const {
                         peerObject.insert("status_str", "Active");
                     }
                 }
-                //if(peer.contains("distance") && peer["distance"].is_()) {}
+                if(peer.contains("distance") && peer["distance"].is_number_integer()) {
+                    peerObject.insert("distance", peer["distance"].get<int>());
+                }
                 peersList.append(peerObject);
             }
         }

--- a/src/neroshop_config.hpp
+++ b/src/neroshop_config.hpp
@@ -29,15 +29,15 @@
 
 #define NEROSHOP_RECV_BUFFER_SIZE            4096//8192// no IP packet can be above 64000 (64 KB), not even with fragmentation, thus recv on an UDP socket can at most return 64 KB (and what is not returned is discarded for the current packet!)
 
-#define NEROSHOP_DHT_REPLICATION_FACTOR      3 // 10 to 20 (or even higher) // Usually 3 or 5 but a higher number would improve fault tolerant, mitigating the risk of data loss even if multiple nodes go offline simultaneously. It also helps distribute the load across more nodes, potentially improving read performance by allowing concurrent access from multiple replicas.
-#define NEROSHOP_DHT_MAX_CLOSEST_NODES       20 // 50 to 100 (or even higher)
-#define NEROSHOP_DHT_RECV_TIMEOUT            5 // A reasonable query recv timeout value for a DHT node could be between 5 to 30 seconds.
-#define NEROSHOP_DHT_PING_TIMEOUT            3//2
-#define NEROSHOP_DHT_ROUTING_TABLE_BUCKETS   256 // Recommended to use a number of buckets that is equal to the number of bits in the node id (in this case, sha-3-256 so 256 bits)
-#define NEROSHOP_DHT_NODES_PER_BUCKET        20 // Each bucket should hold up to 20 nodes (same number as k closest nodes)
+#define NEROSHOP_DHT_REPLICATION_FACTOR      3    // 10 to 20 (or even higher) // Usually 3 or 5 but a higher number would improve fault tolerant, mitigating the risk of data loss even if multiple nodes go offline simultaneously. It also helps distribute the load across more nodes, potentially improving read performance by allowing concurrent access from multiple replicas.
+#define NEROSHOP_DHT_MAX_CLOSEST_NODES       20   // 50 to 100 (or even higher)
+#define NEROSHOP_DHT_RECV_TIMEOUT            2000 // Measured in milliseconds
+#define NEROSHOP_DHT_PING_TIMEOUT            800  // Measured in milliseconds
+#define NEROSHOP_DHT_ROUTING_TABLE_BUCKETS   256  // Recommended to use a number of buckets that is equal to the number of bits in the node id (in this case, sha-3-256 so 256 bits)
+#define NEROSHOP_DHT_NODES_PER_BUCKET        20   // Each bucket should hold up to 20 nodes (same number as k closest nodes)
 #define NEROSHOP_DHT_MAX_ROUTING_TABLE_NODES NEROSHOP_DHT_ROUTING_TABLE_BUCKETS * NEROSHOP_DHT_NODES_PER_BUCKET // = 5120
-#define NEROSHOP_DHT_MAX_HEALTH_CHECKS       3 // Maximum number of consecutive failed checks before marking the node as dead
-#define NEROSHOP_DHT_NODE_HEALTH_CHECK_INTERVAL 300 // Number of seconds between each node health check
+#define NEROSHOP_DHT_MAX_HEALTH_CHECKS          3    // Maximum number of consecutive failed checks before marking the node as dead
+#define NEROSHOP_DHT_NODE_HEALTH_CHECK_INTERVAL 300  // Number of seconds between each node health check
 #define NEROSHOP_DHT_DATA_REPUBLISH_INTERVAL    3600 // Number of seconds between each republishing of in-memory hash table data
 #define NEROSHOP_DHT_DATA_REMOVAL_INTERVAL      1800 // Number of seconds between each removal of all expired in-memory hash table data
 #define NEROSHOP_DHT_BUCKET_REFRESH_INTERVAL    3600 // Number of seconds between each find_node query to neighboring nodes


### PR DESCRIPTION
* display XOR distance in GUI
* add more log messages
* Timeouts are now measured in milliseconds
    - `NEROSHOP_DHT_PING_TIMEOUT` reduced to 800ms
    - `NEROSHOP_DHT_RECV_TIMEOUT` reduced to 2000ms
* rename `Node::periodic_check()` to `Node::heartbeat()`
* prevent unnecessary `std::shared_ptr<Node>` reference count increments
* create a `static` version of `RoutingTable::get_bucket_index()`
* make `Node` callback functions `private`
* modify `RoutingTable::add_node()`
    - take `std::unique_ptr<Node>` argument instead of `std::shared_ptr<Node>`
    - prevent nodes from adding themselves to their own routing table
* `RoutingTable` is now fully thread-safe and no longer returns raw pointers, instead returns `std::weak_ptr<Node>` and `std::vector<std::weak_ptr<Node>>` for `RoutingTable::get_node_by_id()` and `RoutingTable::find_closest_node()`
* replace `getpwuid` with the thread-safe version, `getpwuid_r`