### PR TITLE
optimize sqlite for concurrent writes

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -28,6 +28,7 @@ set(sqlite_srcs sqlite/sqlite3.c)
 add_library(${sqlite3} STATIC ${sqlite_srcs})
 target_include_directories(${sqlite3} PUBLIC sqlite/)
 target_compile_definitions(${sqlite3} PUBLIC SQLITE_ENABLE_FTS5)
+target_compile_definitions(${sqlite3} PUBLIC SQLITE_THREADSAFE=1) # 1=serialized mode (default), 0=single-thread, 2=multi-thread
 
 set(linenoise_target "linenoise")
 set(linenoise_srcs linenoise/linenoise.c)

--- a/src/core/database/database.cpp
+++ b/src/core/database/database.cpp
@@ -7,7 +7,12 @@ namespace neroshop {
 db::Sqlite3 * get_database() {
     std::string database_path = neroshop::get_default_database_path();
     std::string database_file = NEROSHOP_DATABASE_FILENAME;
+    // Clients must NEVER write to the main database at any moment!!
+    #if defined(NEROSHOP_BUILD_GUI) || defined(NEROSHOP_BUILD_CLI)
+    static db::Sqlite3 database_obj { database_path + "/" + database_file, SQLITE_OPEN_READONLY };
+    #else
     static db::Sqlite3 database_obj { database_path + "/" + database_file };
+    #endif
     return &database_obj;
 }
 

--- a/src/core/database/sqlite3/sqlite3.hpp
+++ b/src/core/database/sqlite3/sqlite3.hpp
@@ -3,7 +3,7 @@
 #ifndef SQLITE3_HPP_NEROSHOP
 #define SQLITE3_HPP_NEROSHOP
 
-constexpr const char* SQLITE3_TAG = "\033[1;36m[sqlite3]:\033[0m ";
+inline constexpr const char* SQLITE3_TAG = "\033[1;36m[sqlite3]:\033[0m ";
 
 #include <sqlite3.h>
 #include <nlohmann/json.hpp>
@@ -11,6 +11,7 @@ constexpr const char* SQLITE3_TAG = "\033[1;36m[sqlite3]:\033[0m ";
 #include <iostream>
 #include <string>
 #include <vector> // std::vector
+#include <mutex>
 
 namespace neroshop {
 
@@ -19,9 +20,9 @@ namespace db {
 class Sqlite3 {
 public:
     Sqlite3();
-	Sqlite3(const std::string& filename);
+	Sqlite3(const std::string& filename, int flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE);
 	~Sqlite3();
-	bool open(const std::string& filename);
+	bool open(const std::string& filename, int flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE);
 	void close();
 	int execute(const std::string& command);
 	int execute_params(const std::string& command, const std::vector<std::string>& args);
@@ -29,6 +30,8 @@ public:
 	static std::string get_sqlite_version();
     sqlite3 * get_handle() const;
     std::string get_file() const;
+    std::string get_name() const;
+    std::mutex & get_mutex();
 	void * get_blob(const std::string& command);
 	void * get_blob_params(const std::string& command, const std::vector<std::string>& args);    
 	std::string get_text(const std::string& command);// const;
@@ -38,19 +41,24 @@ public:
 	double get_real(const std::string& command); // NOTE: both floats and doubles are of the 'real' datatype
 	double get_real_params(const std::string& command, const std::vector<std::string>& args);
 	std::vector<std::string> get_rows(const std::string& command);
+	// setters
+	void set_enable_mutex(bool enabled);
     // boolean
     bool is_open() const;
     bool table_exists(const std::string& table_name);
+    bool is_mutex_enabled() const;
     //bool rowid_exists(const std::string& table_name, int rowid);
     std::pair<int, std::string> get_error() const; // returns the error result of the last query
     static std::string get_select(); // returns the result of the last select statement 
 private:
+    static int callback(void *not_used, int argc, char **argv, char **az_col_name);
 	sqlite3 * handle;
 	bool opened;
 	std::string filename;
-	static int callback(void *not_used, int argc, char **argv, char **az_col_name);
-	std::vector<std::pair<int, std::string>> logger; // arg 1 = error code, arg 2 = error message 
+	std::vector<std::pair<int, std::string>> errors; // arg 1 = error code, arg 2 = error message 
     static nlohmann::json json_object;
+    mutable std::mutex db_mutex;
+    bool enable_mutex;
 };
 
 }

--- a/src/core/market/order.cpp
+++ b/src/core/market/order.cpp
@@ -3,7 +3,7 @@
 #include "cart.hpp"
 #include "../price_api/currency_converter.hpp" // currency converter, enums.hpp
 #include "../settings.hpp" // neroshop::lua_state
-#include "../database/database.hpp"
+////#include "../database/database.hpp"
 #include "../tools/logger.hpp"
 #include "../tools/string.hpp"
 #include "../tools/uuid.hpp" // neroshop::uuid::generate()
@@ -12,6 +12,8 @@
 #include "../tools/timestamp.hpp"
 
 #include <unordered_set>
+
+#include <nlohmann/json.hpp>
 
 namespace neroshop {
 ////////////////////

--- a/src/core/protocol/p2p/key_mapper.hpp
+++ b/src/core/protocol/p2p/key_mapper.hpp
@@ -14,12 +14,11 @@ public:
     KeyMapper() = default;
     ~KeyMapper() noexcept;
 
-    void add(const std::string& key, const std::string& value); // must be JSON value
+    void add(const std::string& key, const std::string& value);
     void sync(); // syncs mapping data to local database
     std::pair<std::string, std::string> serialize(); // Converts mapping data to JSON format
-    
-    ////std::vector<std::string> search_product_by_name(const std::string& product_name);//std::vector<std::string> search_user_by_id(const std::string& );//std::vector<std::string> search_order_by_id(const std::string& );
 private:
+    void clear_cache();
     mutable std::shared_mutex user_mutex;
     mutable std::shared_mutex listing_mutex;
     mutable std::shared_mutex order_mutex;

--- a/src/core/protocol/p2p/node.hpp
+++ b/src/core/protocol/p2p/node.hpp
@@ -66,12 +66,12 @@ public:
     // DHT Query Types
     bool ping(const std::string& destination); // A simple query to check if a node is online and responsive.
     std::vector<Node*> find_node(const std::string& target_id, int count) const;// override; // A query to find the contact information for a specific node in the DHT. // Finds the node closest to the target_id
-    int put(const std::string& key, const std::string& value); // A query to store a value in the DHT.    // Stores the key-value pair in the DHT
-    int store(const std::string& key, const std::string& value);
+    bool put(const std::string& key, const std::string& value); // A query to store a value in the DHT.    // Stores the key-value pair in the DHT
+    bool store(const std::string& key, const std::string& value);
     std::string get(const std::string& key) const; // A query to get a specific value stored in the DHT.         // Retrieves the value associated with the key from the DHT
     std::string find_value(const std::string& key) const;
-    int remove(const std::string& key); // Remove a key-value pair from the DHT
-    int remove_all(); // Remove all data from in-memory hash table
+    bool remove(const std::string& key); // Remove a key-value pair from the DHT
+    bool remove_all(); // Remove all data from in-memory hash table
     void map(const std::string& key, const std::string& value); // Maps search terms to keys
     void add_provider(const std::string& data_hash, const Peer& peer);
     void remove_providers(const std::string& data_hash);
@@ -133,7 +133,7 @@ private:
     // Determines if node1 is closer to the target_id than node2
     bool is_closer(const std::string& target_id, const std::string& node1_id, const std::string& node2_id);
     //---------------------------------------------------
-    int set(const std::string& key, const std::string& value); // Updates the value without changing the key. set cannot be accessed directly but only through put
+    bool set(const std::string& key, const std::string& value); // Updates the value without changing the key. set cannot be accessed directly but only through put
     bool verify(const std::string& value) const;
     void expire(const std::string& key, const std::string& value); // Removes any expired data from hash table
     bool validate_fields(const std::string& value);

--- a/src/core/protocol/transport/sam_client.cpp
+++ b/src/core/protocol/transport/sam_client.cpp
@@ -360,7 +360,7 @@ void SamClient::session_close() {
         ::close(session_socket);               // Actually release the socket
         session_socket = -1;
         #ifdef NEROSHOP_DEBUG
-        std::cout << "SAM session (" << get_nickname() << ") closed\n";
+        std::cout << "SAM session (" << get_nickname() << ") closed\n";//log_debug("SAM: Session {}{}{} closed", color_yellow, get_nickname(), color_reset);
         #endif
     }
 }

--- a/src/core/protocol/transport/sam_client.hpp
+++ b/src/core/protocol/transport/sam_client.hpp
@@ -12,7 +12,7 @@ inline constexpr std::uint16_t SAM_DEFAULT_PORT_TCP   = 7656;
 inline constexpr std::uint16_t SAM_DEFAULT_PORT_UDP   = 7655;
 inline constexpr std::uint16_t SAM_DEFAULT_CLIENT_TCP = 7666;
 inline constexpr std::uint16_t SAM_DEFAULT_CLIENT_UDP = 7667;
-inline constexpr const char* SAM_DEFAULT_PRIVKEY_PATH = "i2p.key";
+inline constexpr const char* SAM_DEFAULT_PRIVKEY_PATH = "i2p.key";//const std::string SAM_DEFAULT_PRIVKEY_PATH = []() { static std::mt19937_64 rng(std::chrono::steady_clock::now().time_since_epoch().count()); uint64_t n = rng(); std::stringstream s; s << "i2p_" << std::hex << n << ".key"; return s.str(); }();
 
 inline constexpr const char* SAM_NAME_INBOUND_QUANTITY          = "inbound.quantity";
 inline constexpr int SAM_DEFAULT_INBOUND_QUANTITY               = 3; // Three tunnels is default now

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -9,9 +9,23 @@
 #include <QStandardPaths>
 #endif
 
-// neroshop (includes both the core headers and the gui headers)
+#include "currency_rate_provider.hpp"
+#include "settings_manager.hpp"
+#include "backend.hpp"
+#include "daemon_manager.hpp"
+#include "proxy_manager.hpp"
+#include "wallet_manager.hpp"
+#include "settings_manager.hpp"
+#include "user_manager.hpp"
+#include "enum_wrapper.hpp"
+#include "wallet_qr_provider.hpp"
+#include "image_provider.hpp"
 #include "../neroshop_config.hpp"
-#include "../neroshop.hpp"
+#include "../core/tools/filesystem.hpp"
+#include "../core/tools/logger.hpp"
+#include "../core/version.hpp"
+#include "../core/settings.hpp"
+
 using namespace neroshop;
 
 static const QString WALLET_QR_PROVIDER {"wallet_qr"};

--- a/src/gui/user_manager.cpp
+++ b/src/gui/user_manager.cpp
@@ -399,13 +399,13 @@ QVariantList neroshop::UserManager::getInventory(int sorting) const {
             // Get the value of the corresponding key from the DHT
             std::string response;
             client->get(key.toStdString(), response); // TODO: error handling
-            std::cout << "Received response (get): " << response << "\n";
+            log_trace("Received response (get): {}", response);
             // Parse the response
             nlohmann::json json = nlohmann::json::parse(response);
             if(json.contains("error")) {
                 std::string response2;
                 client->remove(key.toStdString(), response2);
-                std::cout << "Received response (remove): " << response2 << "\n";
+                log_trace("Received response (remove): {}", response2);
                 //emit productsCountChanged();
                 //emit inventoryChanged();
                 continue; // Key is lost or missing from DHT, skip to next iteration
@@ -659,13 +659,13 @@ QVariantList neroshop::UserManager::getMessages() const {
             // Get the value of the corresponding key from the DHT
             std::string response;
             client->get(key.toStdString(), response); // TODO: error handling
-            std::cout << "Received response (get): " << response << "\n";
+            log_trace("Received response (get): {}", response);
             // Parse the response
             nlohmann::json json = nlohmann::json::parse(response);
             if(json.contains("error")) {
                 std::string response2;
                 client->remove(key.toStdString(), response2);
-                std::cout << "Received response (remove): " << response2 << "\n";
+                log_trace("Received response (remove): {}", response2);
                 continue; // Key is lost or missing from DHT, skip to next iteration
             }
             


### PR DESCRIPTION
* include only necessary headers in `src/gui/main.cpp`
* ensure SQLite is compiled in `THREADSAFE` mode
* clients now open "_main_" database in `READONLY` mode
* replace `sqlite3_open()` with `sqlite3_open_v2()` to allow setting flags
* rename `Sqlite3::logger` to `Sqlite3::errors`
* add option to enable **app-level** locks (`std::mutex`) for SQLite queries
    - off by default
* move `KeyMapper` container removals to `clear_cache()` function and lock containers for a short time to achieve higher concurrency
* check/validate user avatar sizes
* change return type of `Node::put()`, `Node::store()` and `Node::remove*()` from `int` to `bool`
* replace some standard output to log outputs