### PR TITLE
fix price sortings

### DIFF
--- a/src/gui/currency_rate_provider.hpp
+++ b/src/gui/currency_rate_provider.hpp
@@ -14,10 +14,12 @@ class CurrencyExchangeRatesProvider : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(int reevaluate READ reevaluate NOTIFY ratesUpdated)
+    Q_DISABLE_COPY(CurrencyExchangeRatesProvider)
 public:
     explicit CurrencyExchangeRatesProvider();
     ~CurrencyExchangeRatesProvider();
     static QObject *qmlInstance(QQmlEngine *engine, QJSEngine *scriptEngine);
+    static CurrencyExchangeRatesProvider* instance();
 
     int reevaluate() const;
 

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -70,15 +70,10 @@ int main(int argc, char *argv[])
     app.setApplicationName("neroshop");
 
     qmlRegisterSingletonType<CurrencyExchangeRatesProvider>(
-        "neroshop",
-        1, 0,
-        "CurrencyExchangeRatesProvider",
+        "neroshop", 1, 0, "CurrencyExchangeRatesProvider",
         &CurrencyExchangeRatesProvider::qmlInstance);
     qmlRegisterSingletonType(QUrl("qrc:/qml/components/CurrencyExchangeRates.qml"),
-                             "neroshop.CurrencyExchangeRates",
-                             1,
-                             0,
-                             "CurrencyExchangeRates");
+        "neroshop.CurrencyExchangeRates", 1, 0, "CurrencyExchangeRates");
 
     QQmlApplicationEngine engine;
     //--------------------------


### PR DESCRIPTION
* prices are now sorted by **XMR** price equivalent
* changes made to `src/gui/currency_rate_provider`
    - create `CurrencyExchangeRatesProvider::instance()` for `static` singleton instance
    - protect `mCurrentRates` with mutex whenever used or modified
    - initialize `mCurrentRates` with desired pairs: **XMR/USD** | **XMR/EUR**