### PR TITLE
fix search engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@
 NeroShop is a decentralized peer-to-peer marketplace for trading goods and services with [**Monero**](https://getmonero.org/)
 
 
-> __Disclaimer: The neroshop team operates independently
+> [!Important]
+> The neroshop team operates independently
 > and is not affiliated, associated, authorized, endorsed by, or in any way officially connected
-> with the Monero project, Monero team or any organization.__
+> with the Monero project, Monero team or any organization.
 
 
 ## Table of Contents
@@ -162,7 +163,8 @@ cd ../
 ```
 
 <!-- git submodule update --init --force --recursive --> <!-- <= call this before building monero -->
-> Tip: Avoid using the `-j$(nproc)` option if you have <= 4 CPU cores and <= 4GB RAM to prevent system crashes. Use `-j1` instead.
+> [!Tip]
+> Avoid using the `-j$(nproc)` option if you have <= 4 CPU cores and <= 4GB RAM to prevent system crashes. Use `-j1` instead.
 
 **4. Build monero-project to create .a libraries**
 ```bash

--- a/qml/components/ProductDialog.qml
+++ b/qml/components/ProductDialog.qml
@@ -177,6 +177,9 @@ Popup {
                             radius: productDialog.inputRadius
                             color: productDialog.inputBaseColor
                             textColor: productDialog.inputTextColor
+                            onActivated: {
+                                productPriceField.adjustPriceDecimals()
+                            }
                         }
                     }
                 }

--- a/qml/components/ProductDialog.qml
+++ b/qml/components/ProductDialog.qml
@@ -178,7 +178,9 @@ Popup {
                             color: productDialog.inputBaseColor
                             textColor: productDialog.inputTextColor
                             onActivated: {
-                                productPriceField.adjustPriceDecimals()
+                                if(productPriceField.text.length > 0) {
+                                    productPriceField.adjustPriceDecimals()
+                                }
                             }
                         }
                     }

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -247,7 +247,7 @@ int main(int argc, char** argv)
     
     db::Sqlite3 * database = neroshop::get_database();
     if(!database->table_exists("mappings")) { 
-        database->execute("CREATE VIRTUAL TABLE mappings USING fts5(search_term, key, content, tokenize = \"porter unicode61 remove_diacritics 1 tokenchars '-_'\");"); // 0=uses accent characters (diacritics) like é; default is 1
+        database->execute("CREATE VIRTUAL TABLE mappings USING fts5(search_term, key, content, tokenize = \"porter unicode61 remove_diacritics 1 tokenchars '-_:'\");"); // 0=uses accent characters (diacritics) like é; default is 1
     }
     //-------------------------------------------------------
     neroshop::Node node(true);

--- a/src/gui/backend.cpp
+++ b/src/gui/backend.cpp
@@ -1160,7 +1160,9 @@ QVariantList neroshop::Backend::getListingsBySearchTerm(const QString& searchTer
     //-------------------------------------------------------
     // Bind value to parameter arguments
     QByteArray searchTermByteArray = searchTerm.toUtf8(); // Convert QString to std::string equivalent
-    if(sqlite3_bind_text(stmt, 1, searchTermByteArray.constData(), searchTermByteArray.length(), SQLITE_STATIC) != SQLITE_OK) {
+    // Wrap searchTerm in double quotes for exact matching tokens with colon
+    std::string quotedSearchTerm = std::string("\"") + searchTermByteArray.constData() + "\"";
+    if(sqlite3_bind_text(stmt, 1, quotedSearchTerm.c_str(), quotedSearchTerm.length(), SQLITE_STATIC) != SQLITE_OK) {
         neroshop::log_error("sqlite3_bind_text: " + std::string(sqlite3_errmsg(database->get_handle())));
         sqlite3_finalize(stmt);
         return {};//database->execute("ROLLBACK;"); return {};


### PR DESCRIPTION
- adjust price decimals when `currencyBox` is activated
- edit `README.md`
- improvements made to search
    - able to search words containing colons (`:`), dashes/hyphens (`-`), as well as apostrophes (`'`)
    - **port stemming** (`porter`) still works as it did before (e.g. `-ing`, `-es`, `-s`, etc.)
    - prefix matching also works as it did before

> [!Note]
> This is a breaking change that requires the old `~/.config/neroshop/datastore/data.sqlite3` database to be deleted before running `neroshopd`.