### PR TITLE
skip duplicate variants

### DIFF
--- a/qml/components/ProductDialog.qml
+++ b/qml/components/ProductDialog.qml
@@ -1847,7 +1847,6 @@ Popup {
                                 ////paymentCoinsItem.uncheckAllPaymentCoins()
                                 deliveryOptionsItem.uncheckAllDeliveryOptions()
                                 shippingOptionsItem.uncheckAllShippingOptions()
-                                nsfwBox.checked = false
                                 // Clear upload images as well
                                 for(let i = 0; i < productImageRepeater.count; i++) {
                                     let productImage = productImageRepeater.itemAt(i).children[0].children[0]

--- a/src/core/market/order.cpp
+++ b/src/core/market/order.cpp
@@ -18,7 +18,7 @@
 namespace neroshop {
 ////////////////////
 Order::Order() : status(OrderStatus::New), subtotal(0.00), discount(0.00), shipping_cost(0.00), total(0.00), 
-    payment_option(PaymentOption::Escrow), payment_coin(PaymentCoin::Monero), delivery_option(DeliveryOption::Shipping)
+    payment_option(PaymentOption::Escrow), payment_coin(PaymentCoin::XMR), delivery_option(DeliveryOption::Shipping)
 {}
 
 Order::Order(const std::string& id, const std::string& date, OrderStatus status, const std::string& customer_id,
@@ -162,7 +162,7 @@ void Order::create_order(const neroshop::Cart& cart, const std::string& shipping
     auto order_status = OrderStatus::New;
     std::string customer_id = cart.owner_id;
     auto payment_option = PaymentOption::Escrow;
-    auto payment_coin = PaymentCoin::Monero;
+    auto payment_coin = PaymentCoin::XMR;
     auto delivery_option = DeliveryOption::Shipping;
     std::string notes = shipping_address;
     
@@ -307,7 +307,7 @@ void Order::create_order_batch(const neroshop::Cart& cart, const std::string& sh
         auto order_status = OrderStatus::New;
         std::string customer_id = cart.owner_id;
         auto payment_option = PaymentOption::Escrow;
-        auto payment_coin = PaymentCoin::Monero;
+        auto payment_coin = PaymentCoin::XMR;
         auto delivery_option = DeliveryOption::Shipping;
         std::string notes = shipping_address;
     
@@ -455,8 +455,8 @@ void Order::set_payment_coin(PaymentCoin payment_coin) {
 
 void Order::set_payment_coin_by_string(const std::string& payment_coin) {
     if(payment_coin == "None") set_payment_coin(PaymentCoin::None);
-    if(payment_coin == "Monero") set_payment_coin(PaymentCoin::Monero);
-    if(payment_coin == "Wownero") set_payment_coin(PaymentCoin::Wownero);
+    if(payment_coin == "Monero") set_payment_coin(PaymentCoin::XMR);
+    if(payment_coin == "Wownero") set_payment_coin(PaymentCoin::WOW);
     //if(payment_coin == "") set_payment_coin(PaymentCoin::);
 }
 

--- a/src/core/market/payment.hpp
+++ b/src/core/market/payment.hpp
@@ -37,8 +37,8 @@ enum class PaymentOption {
 // payment coins (cryptocurrencies used for payments)
 enum class PaymentCoin { 
     None = -1, // Intended for non-crypto payment methods
-    Monero,
-    Wownero,
+    XMR,
+    WOW,
 };
 
 //-----------------------------------------------------------------------------
@@ -58,8 +58,8 @@ inline std::string get_payment_method_as_string(PaymentMethod payment_method) {
 inline std::string get_payment_coin_as_string(PaymentCoin payment_coin) {
     switch(payment_coin) {
         case PaymentCoin::None: return "None";
-        case PaymentCoin::Monero: return "XMR";
-        case PaymentCoin::Wownero: return "WOW";
+        case PaymentCoin::XMR: return "XMR";
+        case PaymentCoin::WOW: return "WOW";
         default: return "";
     }
 }

--- a/src/core/market/product.cpp
+++ b/src/core/market/product.cpp
@@ -11,7 +11,7 @@ namespace neroshop {
 
 //-----------------------------------------------------------------------------
 
-Product::Product() : id(""), name(""), description(""), weight(0.0), code(""), category_id(0), subcategory_ids({}) {}
+Product::Product() : weight(0.0), category_id(0) {}
 
 //-----------------------------------------------------------------------------
 
@@ -111,8 +111,11 @@ void Product::add_variant(const ProductVariant& variant) {
     if (variant.options.size() > max_options_per_variant) {
         throw std::runtime_error("Too many options in variant, max allowed is " + std::to_string(max_options_per_variant));
     }
-    variants.push_back(variant);
-    validate_variants();
+    
+    if (!variant_exists(variant)) {
+        variants.push_back(variant);
+        validate_variants();
+    }
 }
 
 // Supports both single-option products (e.g. just “color”) and multi-option combinations
@@ -422,6 +425,19 @@ neroshop::Image Product::get_image(int index) const {
 
 std::vector<neroshop::Image> Product::get_images() const {
     return images;
+}
+
+//-----------------------------------------------------------------------------
+
+bool Product::variant_exists(const ProductVariant& variant) const {
+    for (const auto& v : variants) {
+        // Compare the options maps — assumes order doesn't matter
+        if (v.options == variant.options) {
+            // Optionally compare other fields, e.g. condition, price, etc.
+            return true;
+        }
+    }
+    return false;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/core/market/product.hpp
+++ b/src/core/market/product.hpp
@@ -70,6 +70,8 @@ public:
     std::set<std::string> get_tags() const;
     Image get_image(int index) const;
     std::vector<Image> get_images() const;
+    
+    bool variant_exists(const ProductVariant& variant) const;
 private:
     void validate_variants() const;
     std::string id;


### PR DESCRIPTION
- rename `PaymentCoin::Monero` to `PaymentCoin::XMR` and `PaymentCoin::Wownero` to `PaymentCoin::WOW`
- don't reset `nsfw.checked` manually as it already resets automatically
- skip duplicate variants from being serialized